### PR TITLE
Ghidra DecompilerActionContext Right-click type judgment solution.

### DIFF
--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
@@ -71,8 +71,7 @@ public class RenameLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
-		EquateTable equateTable = context.getProgram().getEquateTable();
-		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+		if (highSymbol instanceof EquateSymbol) {
 			return false;
 		}
 		return !highSymbol.isGlobal();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RenameLocalAction.java
@@ -71,6 +71,10 @@ public class RenameLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
+		EquateTable equateTable = context.getProgram().getEquateTable();
+		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+			return false;
+		}
 		return !highSymbol.isGlobal();
 	}
 

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
@@ -144,8 +144,7 @@ public class RetypeLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
-		EquateTable equateTable = context.getProgram().getEquateTable();
-		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+		if (highSymbol instanceof EquateSymbol) {
 			return false;
 		}
 		return !highSymbol.isGlobal();

--- a/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
+++ b/Ghidra/Features/Decompiler/src/main/java/ghidra/app/plugin/core/decompile/actions/RetypeLocalAction.java
@@ -144,6 +144,10 @@ public class RetypeLocalAction extends AbstractDecompilerAction {
 		if (highSymbol == null) {
 			return false;
 		}
+		EquateTable equateTable = context.getProgram().getEquateTable();
+		if (equateTable.getEquate(tokenAtCursor.getText()) != null) {
+			return false;
+		}
 		return !highSymbol.isGlobal();
 	}
 


### PR DESCRIPTION
This should fix [this issue](https://github.com/StarCrossPortal/bincraft/issues/16): when program judge "DecompilerContext" enabled or not, I add a new judgment.

This judgment I add will determine whether the content exists in EquateTable, and then react differently. 